### PR TITLE
GH-1 feat: add gesture support and accessibility improvements to coun…

### DIFF
--- a/app/src/main/java/com/example/kastenderpandora/BaseToolActivity.kt
+++ b/app/src/main/java/com/example/kastenderpandora/BaseToolActivity.kt
@@ -1,12 +1,14 @@
 package com.example.kastenderpandora
 
 import android.os.Bundle
+import android.view.MotionEvent
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import com.example.kastenderpandora.utils.SwipeGestureDetector
 
 abstract class BaseToolActivity : AppCompatActivity() {
 
@@ -14,6 +16,9 @@ abstract class BaseToolActivity : AppCompatActivity() {
     open val toolIcon: Int = R.drawable.ic_placeholder
     open val layoutResId: Int = R.layout.activity_tool_placeholder
     open val showBackButton: Boolean = true
+    open val enableSwipeBack: Boolean = false
+
+    private var swipeGestureDetector: SwipeGestureDetector? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,7 +28,13 @@ abstract class BaseToolActivity : AppCompatActivity() {
         setupWindowInsets()
         setupHeader()
         setupBackButton()
+        setupSwipeGestures()
         setupToolContent()
+    }
+
+    override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
+        swipeGestureDetector?.onTouchEvent(ev)
+        return super.dispatchTouchEvent(ev)
     }
 
     private fun setupWindowInsets() {
@@ -50,6 +61,15 @@ abstract class BaseToolActivity : AppCompatActivity() {
             }
         } else {
             backButton?.visibility = android.view.View.GONE
+        }
+    }
+
+    private fun setupSwipeGestures() {
+        if (enableSwipeBack) {
+            swipeGestureDetector = SwipeGestureDetector(
+                this,
+                onSwipeLeft = { onBackButtonPressed() }
+            )
         }
     }
 

--- a/app/src/main/java/com/example/kastenderpandora/CounterActivity.kt
+++ b/app/src/main/java/com/example/kastenderpandora/CounterActivity.kt
@@ -1,20 +1,24 @@
 package com.example.kastenderpandora
 
 import android.os.Bundle
+import android.view.GestureDetector
+import android.view.MotionEvent
 import android.widget.Button
-import android.widget.TextView
+import com.example.kastenderpandora.ui.ClickableTextView
 
 class CounterActivity : BaseToolActivity() {
 
     override val toolTitle = R.string.counter
     override val layoutResId = R.layout.activity_counter
+    override val enableSwipeBack = true
 
     private var count = 0
+    private var doubleTapDetector: GestureDetector? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val tvCount = findViewById<TextView>(R.id.tvCount)
+        val tvCount = findViewById<ClickableTextView>(R.id.tvCount)
         val btnPlus = findViewById<Button>(R.id.btnPlus)
         val btnMinus = findViewById<Button>(R.id.btnMinus)
         val btnReset = findViewById<Button>(R.id.btnReset)
@@ -37,6 +41,30 @@ class CounterActivity : BaseToolActivity() {
             count = 0
             updateCount()
         }
+
+        tvCount.isClickable = true
+
+        tvCount.setOnTouchListener { view, event ->
+            val handled = doubleTapDetector?.onTouchEvent(event) ?: false
+            if (!handled && event.action == MotionEvent.ACTION_UP) {
+                view.performClick()
+            }
+            handled
+        }
+
+        doubleTapDetector = GestureDetector(this, object : GestureDetector.SimpleOnGestureListener() {
+            override fun onDoubleTap(e: MotionEvent): Boolean {
+                tvCount.performClick()
+                count = 0
+                updateCount()
+                return true
+            }
+
+            override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+                tvCount.performClick()
+                return true
+            }
+        })
 
         updateCount()
     }

--- a/app/src/main/java/com/example/kastenderpandora/ui/ClickableTextView.kt
+++ b/app/src/main/java/com/example/kastenderpandora/ui/ClickableTextView.kt
@@ -1,0 +1,17 @@
+package com.example.kastenderpandora.ui
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.appcompat.widget.AppCompatTextView
+
+class ClickableTextView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : AppCompatTextView(context, attrs, defStyleAttr) {
+
+    override fun performClick(): Boolean {
+        super.performClick()
+        return true
+    }
+}

--- a/app/src/main/java/com/example/kastenderpandora/utils/SwipeGestureDetector.kt
+++ b/app/src/main/java/com/example/kastenderpandora/utils/SwipeGestureDetector.kt
@@ -1,0 +1,79 @@
+package com.example.kastenderpandora.utils
+
+import android.content.Context
+import android.view.GestureDetector
+import android.view.MotionEvent
+import kotlin.math.abs
+
+class SwipeGestureDetector(
+    context: Context,
+    private val onSwipeLeft: () -> Unit = {},
+    private val onSwipeRight: () -> Unit = {},
+    private val onSwipeUp: () -> Unit = {},
+    private val onSwipeDown: () -> Unit = {}
+) : GestureDetector.OnGestureListener {
+
+    private val gestureDetector = GestureDetector(context, this)
+
+    private val swipeThreshold = 100
+    private val swipeVelocityThreshold = 100
+
+    fun onTouchEvent(event: MotionEvent): Boolean {
+        return gestureDetector.onTouchEvent(event)
+    }
+
+    override fun onDown(e: MotionEvent): Boolean {
+        return true
+    }
+
+    override fun onShowPress(e: MotionEvent) {}
+
+    override fun onSingleTapUp(e: MotionEvent): Boolean {
+        return false
+    }
+
+    override fun onScroll(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        distanceX: Float,
+        distanceY: Float
+    ): Boolean {
+        return false
+    }
+
+    override fun onLongPress(e: MotionEvent) {}
+
+    override fun onFling(
+        e1: MotionEvent?,
+        e2: MotionEvent,
+        velocityX: Float,
+        velocityY: Float
+    ): Boolean {
+        e1 ?: return false
+
+        val diffX = e2.x - e1.x
+        val diffY = e2.y - e1.y
+
+        if (abs(diffX) > abs(diffY)) {
+            if (abs(diffX) > swipeThreshold && abs(velocityX) > swipeVelocityThreshold) {
+                if (diffX > 0) {
+                    onSwipeRight()
+                } else {
+                    onSwipeLeft()
+                }
+                return true
+            }
+        } else {
+            if (abs(diffY) > swipeThreshold && abs(velocityY) > swipeVelocityThreshold) {
+                if (diffY > 0) {
+                    onSwipeDown()
+                } else {
+                    onSwipeUp()
+                }
+                return true
+            }
+        }
+
+        return false
+    }
+}

--- a/app/src/main/res/layout/activity_counter.xml
+++ b/app/src/main/res/layout/activity_counter.xml
@@ -17,7 +17,7 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
-    <TextView
+    <com.example.kastenderpandora.ui.ClickableTextView
         android:id="@+id/tvCount"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Users rely on touch gestures and accessibility features for comfortable interaction. The counter tool lacked swipe navigation and proper accessibility support, making it difficult for users with motor impairments or screen readers to use efficiently.

Created reusable SwipeGestureDetector utility that provides consistent gesture handling across all activities. Added enableSwipeBack property to BaseToolActivity for opt-in navigation gestures. Implemented double-tap to reset on counter display with performClick() calls for TalkBack compatibility, ensuring gesture callbacks trigger proper accessibility events.